### PR TITLE
Conditional Webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/*.DS_Store
+/CloudFormation.json

--- a/02_Metadata/interface.json
+++ b/02_Metadata/interface.json
@@ -1,0 +1,27 @@
+{
+	"AWS::CloudFormation::Interface" : {
+		"ParameterGroups": [
+			{
+				"Label" : { "default" : "Basics" },
+				"Parameters" : [ "CodePipelineArtifactsParam" ]
+			},
+			{
+				"Label" : { "default" : "GitHub" },
+				"Parameters" : [ "GitHubAccountOwnerParam", "GitHubTokenParam", "StageParam", "AutoDeployParam" ]
+			},
+			{
+				"Label" : { "default" : "Product Configuration" },
+				"Parameters" : [ "EmailRestingPlace"]
+			}
+		],
+		"ParameterLabels": {
+			"CodePipelineArtifactsParam": { "default" : "CodePipeline Artifacts" },
+			"GitHubTokenParam": { "default" : "GitHub Token" },
+			"GitHubAccountOwnerParam": { "default" : "GitHub Owner" },
+			"StageParam": { "default" : "Deployment Stage" },
+			"AutoDeployParam": { "default" : "Autodeployment" },
+
+			"EmailRestingPlace": { "default" : "Email Bucket Name" }
+		}
+	}
+}

--- a/03_Parameters/auto_deploy.json
+++ b/03_Parameters/auto_deploy.json
@@ -1,0 +1,8 @@
+{
+	"AutoDeployParam": {
+		"Description": "Don't change this unless you forked your own copy of the repos. And want to have auto deployment for changes in code that you made in your repos. If you set Yes, then the CodePipeline setup will get a Webhook resource, otherwise skipped, since you don't have access to our repos, and can't add a web hook entry in our repos.",
+		"Type": "String",
+		"AllowedValues" : ["No", "Yes"],
+		"Default": "No"
+	}
+}

--- a/03_Parameters/code_pipeline_bucket_name.json
+++ b/03_Parameters/code_pipeline_bucket_name.json
@@ -1,5 +1,5 @@
 {
-	"CodePipelineBucketName": {
+	"CodePipelineArtifactsParam": {
 		"Description": "The S3 bucket name where CodePipeline will store the artifacts (this is needed only by CP to work, and pass task results to the next stage) - (This bucket needs to exist already in S3)",
 		"Type": "String"
 	}

--- a/03_Parameters/github_account_name.json
+++ b/03_Parameters/github_account_name.json
@@ -1,7 +1,0 @@
-{
-	"ParamGitHubAccountName": {
-		"Description": "The name of the GitHub account, it is the same names that you find in the URL. Organization or private account.",
-		"Type": "String",
-		"Default": "0x4447"
-	}
-}

--- a/03_Parameters/github_owner.json
+++ b/03_Parameters/github_owner.json
@@ -1,0 +1,7 @@
+{
+	"GitHubAccountOwnerParam": {
+		"Description": "The name of the GitHub account, it is the same names that you find in the URL (Organization or private account).",
+		"Type": "String",
+		"Default": "0x4447"
+	}
+}

--- a/03_Parameters/github_token.json
+++ b/03_Parameters/github_token.json
@@ -1,6 +1,6 @@
 {
-	"GitHubToken": {
-		"Description": "You need to create a Personal access tokens (https://github.com/settings/tokens) for CodePipeline to have access to the GitHub repo even if they are public, and the Scope has to have: repo and admin:repo_hook",
+	"GitHubTokenParam": {
+		"Description": "You need to create a Personal access tokens (https://github.com/settings/tokens) for CodePipeline to have access to the GitHub repo despite it being public. Find out more here: https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-authentication.html",
 		"NoEcho": true,
 		"Type": "String"
 	}

--- a/03_Parameters/stage.json
+++ b/03_Parameters/stage.json
@@ -1,6 +1,6 @@
 {
-	"Stage": {
-		"Description": "Select what Stage are you deploying.",
+	"StageParam": {
+		"Description": "Select what type of environment are you deploying (branch of the repo).",
 		"Type": "String",
 		"AllowedValues": ["master", "development"],
 		"Default": "master",

--- a/05_Conditions/github_owner.json
+++ b/05_Conditions/github_owner.json
@@ -1,0 +1,3 @@
+{
+	"GitHubAutodeploymentCondition": { "Fn::Equals": [ {"Ref": "AutoDeployParam"}, "Yes"] }
+}

--- a/07_Resources/Repos/converter/CodeBuild/Policies/s3.json
+++ b/07_Resources/Repos/converter/CodeBuild/Policies/s3.json
@@ -10,7 +10,7 @@
 					{
 						"Effect": "Allow",
 						"Action": "s3:*",
-						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineBucketName}/*"}
+						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineArtifactsParam}/*"}
 					}
 				]
 			}

--- a/07_Resources/Repos/converter/CodePipeline/_index.json
+++ b/07_Resources/Repos/converter/CodePipeline/_index.json
@@ -4,7 +4,7 @@
 		"Properties": {
 			"Name": "0x4447_s3_email_lambda_converter",
 			"ArtifactStore": {
-				"Location": { "Ref": "CodePipelineBucketName" },
+				"Location": { "Ref": "CodePipelineArtifactsParam" },
 				"Type": "S3"
 			},
 			"RoleArn": { "Fn::GetAtt": ["PipelineConverterRole", "Arn"] },
@@ -22,11 +22,11 @@
 								"Version": "1"
 							},
 							"Configuration": {
-								"Owner": { "Ref": "ParamGitHubAccountName" },
+								"Owner": { "Ref": "GitHubAccountOwnerParam" },
 								"Repo": "0x4447_product_s3_email_lambda_converter",
-								"Branch": { "Ref": "Stage" },
+								"Branch": { "Ref": "StageParam" },
 								"PollForSourceChanges": false,
-								"OAuthToken": { "Ref": "GitHubToken" }
+								"OAuthToken": { "Ref": "GitHubTokenParam" }
 							},
 							"OutputArtifacts": [
 								{

--- a/07_Resources/Repos/converter/CodePipeline/webhook.json
+++ b/07_Resources/Repos/converter/CodePipeline/webhook.json
@@ -1,6 +1,7 @@
 {
 	"PipelineConverterWebhook": {
 		"Type": "AWS::CodePipeline::Webhook",
+		"Condition": "GitHubAutodeploymentCondition",
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {

--- a/07_Resources/Repos/converter/CodePipeline/webhook.json
+++ b/07_Resources/Repos/converter/CodePipeline/webhook.json
@@ -5,7 +5,7 @@
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {
-				"SecretToken": { "Ref": "GitHubToken" }
+				"SecretToken": { "Ref": "GitHubTokenParam" }
 			},
 			"Filters": [
 				{

--- a/07_Resources/Repos/inbound/CodeBuild/Policies/s3.json
+++ b/07_Resources/Repos/inbound/CodeBuild/Policies/s3.json
@@ -10,7 +10,7 @@
 					{
 						"Effect": "Allow",
 						"Action": "s3:*",
-						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineBucketName}/*"}
+						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineArtifactsParam}/*"}
 					}
 				]
 			}

--- a/07_Resources/Repos/inbound/CodePipeline/_index.json
+++ b/07_Resources/Repos/inbound/CodePipeline/_index.json
@@ -4,7 +4,7 @@
 		"Properties": {
 			"Name": "0x4447_s3_email_lambda_inbound",
 			"ArtifactStore": {
-				"Location": { "Ref": "CodePipelineBucketName" },
+				"Location": { "Ref": "CodePipelineArtifactsParam" },
 				"Type": "S3"
 			},
 			"RoleArn": { "Fn::GetAtt": ["PipelineInboundRole", "Arn"] },
@@ -22,11 +22,11 @@
 								"Version": "1"
 							},
 							"Configuration": {
-								"Owner": { "Ref": "ParamGitHubAccountName" },
+								"Owner": { "Ref": "GitHubAccountOwnerParam" },
 								"Repo": "0x4447_product_s3_email_lambda_inbound",
-								"Branch": { "Ref": "Stage" },
+								"Branch": { "Ref": "StageParam" },
 								"PollForSourceChanges": false,
-								"OAuthToken": { "Ref": "GitHubToken" }
+								"OAuthToken": { "Ref": "GitHubTokenParam" }
 							},
 							"OutputArtifacts": [
 								{

--- a/07_Resources/Repos/inbound/CodePipeline/webhook.json
+++ b/07_Resources/Repos/inbound/CodePipeline/webhook.json
@@ -1,6 +1,7 @@
 {
 	"PipelineInboundWebhook": {
 		"Type": "AWS::CodePipeline::Webhook",
+		"Condition": "GitHubAutodeploymentCondition",
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {

--- a/07_Resources/Repos/inbound/CodePipeline/webhook.json
+++ b/07_Resources/Repos/inbound/CodePipeline/webhook.json
@@ -5,7 +5,7 @@
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {
-				"SecretToken": { "Ref": "GitHubToken" }
+				"SecretToken": { "Ref": "GitHubTokenParam" }
 			},
 			"Filters": [
 				{

--- a/07_Resources/Repos/outbound/CodeBuild/Policies/s3.json
+++ b/07_Resources/Repos/outbound/CodeBuild/Policies/s3.json
@@ -10,7 +10,7 @@
 					{
 						"Effect": "Allow",
 						"Action": "s3:*",
-						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineBucketName}/*"}
+						"Resource": { "Fn::Sub": "arn:aws:s3:::${CodePipelineArtifactsParam}/*"}
 					}
 				]
 			}

--- a/07_Resources/Repos/outbound/CodePipeline/_index.json
+++ b/07_Resources/Repos/outbound/CodePipeline/_index.json
@@ -4,7 +4,7 @@
 		"Properties": {
 			"Name": "0x4447_s3_email_lambda_outbound",
 			"ArtifactStore": {
-				"Location": { "Ref": "CodePipelineBucketName" },
+				"Location": { "Ref": "CodePipelineArtifactsParam" },
 				"Type": "S3"
 			},
 			"RoleArn": { "Fn::GetAtt": ["PipelineOutboundRole", "Arn"] },
@@ -22,11 +22,11 @@
 								"Version": "1"
 							},
 							"Configuration": {
-								"Owner": { "Ref": "ParamGitHubAccountName" },
+								"Owner": { "Ref": "GitHubAccountOwnerParam" },
 								"Repo": "0x4447_product_s3_email_lambda_outbound",
-								"Branch": { "Ref": "Stage" },
+								"Branch": { "Ref": "StageParam" },
 								"PollForSourceChanges": false,
-								"OAuthToken": { "Ref": "GitHubToken" }
+								"OAuthToken": { "Ref": "GitHubTokenParam" }
 							},
 							"OutputArtifacts": [
 								{

--- a/07_Resources/Repos/outbound/CodePipeline/webhook.json
+++ b/07_Resources/Repos/outbound/CodePipeline/webhook.json
@@ -5,7 +5,7 @@
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {
-				"SecretToken": { "Ref": "GitHubToken" }
+				"SecretToken": { "Ref": "GitHubTokenParam" }
 			},
 			"Filters": [
 				{

--- a/07_Resources/Repos/outbound/CodePipeline/webhook.json
+++ b/07_Resources/Repos/outbound/CodePipeline/webhook.json
@@ -1,6 +1,7 @@
 {
 	"PipelineOutboundWebhook": {
 		"Type": "AWS::CodePipeline::Webhook",
+		"Condition": "GitHubAutodeploymentCondition",
 		"Properties": {
 			"Authentication": "GITHUB_HMAC",
 			"AuthenticationConfiguration": {


### PR DESCRIPTION
### Description

Added conditional webhook, by default so the stack can be deployed as is, without forging the repos in to your own account. Since AWS has to updated the setting of a repo with a webhook, that can't be done on repos that you don't own or have access to. In this case you don't have access to our repos.

Issue(s): #30
